### PR TITLE
allow setting of byte limit; increase default to ios 8 limit of 2048 …

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    gs-apns (0.2.0)
+    gs-apns (1.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.textile
+++ b/README.textile
@@ -4,11 +4,11 @@ gs-apns is a gem for accessing the Apple Push Notification Service that allows b
 
 Improvements in *gs-apns*, by William Denniss of "Geospike":http://geospike.com/ :
 
-# Automatic truncation of messages to fit within the 256 byte limit, and an exception thrown if the server payload is too big (better than dying silently)
+# Automatic truncation of messages to fit within the 2048 byte limit, and an exception thrown if the server payload is too big (better than dying silently)
 # Truncation can truncate on word or character boundaries, and UTF-8 is fully supported (specifically, Chinese/Japanese character messages are supported)
 # JSON generation uses the JSON gem directly rather than to_json which is overridden by Rails with the potential for "bugs to be introduced":http://omegadelta.net/2013/04/28/changes-to-how-rails-3-2-13-and-4-0-encodes-unicode-in-json/ .
 # Uses Apple's new 'enhanced' notification protocol allowing for an expiration date to be sent on notifications
-# All 256 of available notification payload can be used (jtv-apns & apns are currently limited to 255)
+# All 2048 of available notification payload can be used (jtv-apns & apns are currently limited to 255)
 
 
 h2. Install

--- a/lib/apns/core.rb
+++ b/lib/apns/core.rb
@@ -52,8 +52,10 @@ module APNS
   
   @logging = true
 
+  @byte_limit = 2048
+
   class << self
-    attr_accessor :host, :port, :feedback_host, :feedback_port, :pem, :pass, :cache_connections, :message_clean_whitespace, :truncate_mode, :truncate_soft_max_chopped, :truncate_ellipsis_str, :logging
+    attr_accessor :host, :port, :feedback_host, :feedback_port, :pem, :pass, :cache_connections, :message_clean_whitespace, :truncate_mode, :truncate_soft_max_chopped, :truncate_ellipsis_str, :logging, :byte_limit
   end
 
   def self.establish_notification_connection
@@ -121,7 +123,7 @@ module APNS
   def self.packaged_notification(device_token, message, identifier, expiry)
     pt = self.packaged_token(device_token)
     pm = self.packaged_message(message)
-    raise APNSException, "payload exceeds 256 byte limit" if pm.bytesize > 256
+    raise APNSException, "payload exceeds #{@byte_limit} byte limit" if pm.bytesize > @byte_limit
 
     #return [0, 32, pt, pm.bytesize, pm].pack("cna*na*") # old format (NB. s> notation only compatible with ruby 1.9.3 and above)
 
@@ -143,7 +145,7 @@ module APNS
     else
       raise "Message needs to be either a hash or string"
     end
-    hash = Truncate.truncate_notification(hash, @message_clean_whitespace, @truncate_mode, @truncate_soft_max_chopped, @truncate_ellipsis_str)
+    hash = Truncate.truncate_notification(hash, @message_clean_whitespace, @truncate_mode, @truncate_soft_max_chopped, @truncate_ellipsis_str, @byte_limit)
     ApnsJSON.apns_json(hash)
   end
   

--- a/lib/apns/version.rb
+++ b/lib/apns/version.rb
@@ -1,3 +1,3 @@
 module APNS
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end

--- a/spec/apns/core_spec.rb
+++ b/spec/apns/core_spec.rb
@@ -26,6 +26,7 @@ require 'spec_helper'
 describe APNS do
 
   APNS.logging = false
+  APNS.byte_limit = 256
 
   it "should encode unicode to ascii-only json" do
     string = "\u2601"


### PR DESCRIPTION
Increase default byte limit to iOS 8 limit of 2048 and allow user to set byte limit in config.